### PR TITLE
Support output format -f name to print name only

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ AudioSwitch requires `cmake` to build.
 Usage
 -----
 
-audioswitch [-a] [-c] [-t type] [-n] -s device_name  
-or  
+audioswitch [-a] [-c] [-t type] [-f format] [-n] -s device_name
+or
 audioswitch -e device_id1=0.5,0.5:device_id2=0.7,0.8
 
  - **-a**               : Lists all devices along with their device IDs.
  - **-c**               : Shows current device.
  - **-t** _type_        : Device type (input/output/system). Defaults to output.
+ - **-f** _format_      : Output format (name/full). Defaults to full.
  - **-n**               : Cycles the audio device to the next one.
  - **-s** _device_name_ : Sets the audio device to the given device by name.
  - **-e** _device_id1_=_vol1_,_vol2_:_device_id2_=_vol1_,_vol2_ : Sets the volume of audio device given by ID, followed by volume of first and second channel respectively. Multiple device can be separated with colon.
@@ -36,7 +37,7 @@ License
 -------
 
 MIT License, see license.txt
-Copyright (c) 2008-2011 Devon Weller <wellerco@gmail.com>  
-Copyright (c) 2011 Christian Zuckschwerdt <zany@triq.net>  
+Copyright (c) 2008-2011 Devon Weller <wellerco@gmail.com>
+Copyright (c) 2011 Christian Zuckschwerdt <zany@triq.net>
 Copyright (c) 2015 [Ziga Zupanec](https://github.com/agiz/) <ziga.zupanec@gmail.com>
 Copyright (c) 2016 Mahmood S. Zargar <mahmood@gmail.com>

--- a/device.c
+++ b/device.c
@@ -287,11 +287,11 @@ bool hasSubdevices(AudioDevicePropertyID device_type) {
     }
 }
 
-void showCurrentlySelectedDeviceID(ASDeviceType typeRequested) {
+void showCurrentlySelectedDeviceID(ASDeviceType typeRequested, ASOutputFormat outputFormat) {
     AudioDeviceID currentDeviceID = kAudioDeviceUnknown;
     currentDeviceID = getCurrentlySelectedDeviceID(typeRequested);
 
-    printProperties(currentDeviceID, typeRequested);
+    printProperties(currentDeviceID, typeRequested, outputFormat);
 }
 
 UInt32 getNumberOfDevices(AudioDeviceID *dev_array) {
@@ -406,13 +406,13 @@ void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested) {
     AudioObjectSetPropertyData(kAudioObjectSystemObject, &pa, 0, NULL, propertySize, &newDeviceID);
 }
 
-void showAllDevices(ASDeviceType typeRequested) {
+void showAllDevices(ASDeviceType typeRequested, ASOutputFormat outputFormat) {
     AudioDeviceID dev_array[64];
     int numberOfDevices = 0;
 
     numberOfDevices = getNumberOfDevices(dev_array);
 
     for (int i = 0; i < numberOfDevices; ++i) {
-        printProperties(dev_array[i], typeRequested);
+        printProperties(dev_array[i], typeRequested, outputFormat);
     }
 }

--- a/device.h
+++ b/device.h
@@ -47,6 +47,11 @@ typedef enum {
     kAudioTypeSystemOutput = 3
 } ASDeviceType;
 
+typedef enum {
+  kOutputFormatDefault = 0,
+  kOutputFormatName = 1
+} ASOutputFormat;
+
 enum {
     kFunctionSetDevice = 1,
     kFunctionShowHelp = 2,
@@ -68,7 +73,7 @@ bool isAnOutputDevice(AudioDeviceID deviceID);
 
 char *deviceTypeName(ASDeviceType device_type);
 
-void showCurrentlySelectedDeviceID(ASDeviceType typeRequested);
+void showCurrentlySelectedDeviceID(ASDeviceType typeRequested, ASOutputFormat outputFormat);
 
 AudioDeviceID getRequestedDeviceID(char *requestedDeviceName, ASDeviceType typeRequested);
 
@@ -76,7 +81,7 @@ AudioDeviceID getNextDeviceID(AudioDeviceID currentDeviceID, ASDeviceType typeRe
 
 void setDevice(AudioDeviceID newDeviceID, ASDeviceType typeRequested);
 
-void showAllDevices(ASDeviceType typeRequested);
+void showAllDevices(ASDeviceType typeRequested, ASOutputFormat outputFormat);
 
 void setDeviceVolume(AudioDeviceID deviceID, float vol_left, float vol_right);
 

--- a/interface.h
+++ b/interface.h
@@ -40,7 +40,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #define VOL_ARG_LEN 1024
 #define VOL_DELIMITERS "=,:"
 
-void printProperties(AudioDeviceID deviceID, ASDeviceType device_type);
+void printProperties(AudioDeviceID deviceID, ASDeviceType device_type, ASOutputFormat outputFormat);
 
 void showUsage(const char *appName);
 


### PR DESCRIPTION
I want to use audioswitch to print the name of the currently used output device on the Touchbar (using BetterTouchTool).

For that I currently rely on `audioswitch -a | ggrep -o -P '(?<=output ).*(?=::)'`. I thought it would be nicer to directly support that output format in audioswitch and just call `./audioswitch -t output -f name -a`

If you don't like the change I'm happy to support it in my personal fork only.